### PR TITLE
gormshema: handle circular FK contraint migrations in postgres

### DIFF
--- a/gormschema/gorm_test.go
+++ b/gormschema/gorm_test.go
@@ -1,6 +1,7 @@
 package gormschema
 
 import (
+	"strings"
 	"testing"
 
 	"ariga.io/atlas-provider-gorm/internal/testdata/models"
@@ -19,4 +20,22 @@ func TestConfig(t *testing.T) {
 	require.Contains(t, sql, "CREATE TABLE `pets`")
 	require.Contains(t, sql, "CREATE TABLE `users`")
 	require.NotContains(t, sql, "FOREIGN KEY")
+}
+
+func TestPostgresConfig(t *testing.T) {
+	l := New("postgres", WithConfig(
+		&gorm.Config{
+			DisableForeignKeyConstraintWhenMigrating: false, // making sure circular FK constraint migration is tested
+		},
+	))
+	sql, err := l.Load(models.Pet{}, models.User{}, models.Toy{})
+	require.NoError(t, err)
+	require.Contains(t, sql, "CREATE TABLE \"pets\"")
+	require.Contains(t, sql, "CREATE TABLE \"users\"")
+	require.Contains(t, sql, "CREATE TABLE \"toys\"")
+
+	// Verify FK constraint is moved to the end
+	stmts := strings.Split(strings.TrimSpace(sql), "\n")
+	require.Contains(t, stmts[len(stmts)-1], "ALTER TABLE \"pets\" ADD CONSTRAINT")
+	require.Contains(t, stmts[len(stmts)-1], "FOREIGN KEY")
 }

--- a/internal/testdata/models/models.go
+++ b/internal/testdata/models/models.go
@@ -10,12 +10,22 @@ type User struct {
 
 type Pet struct {
 	gorm.Model
+	ID     uint
 	Name   string
 	User   User
 	UserID uint
+	Toy    *Toy `gorm:"foreignKey:toy_id;references:id;OnUpdate:CASCADE,OnDelete:CASCADE"`
+	ToyID  uint
 }
 
 type Toy struct {
+	ID    uint
+	Name  string
+	PetID uint
+	Pet   *Pet `gorm:"foreignKey:pet_id;references:id;OnUpdate:CASCADE,OnDelete:CASCADE"`
+}
+
+type House struct {
 	ID   uint
 	Name string
 }

--- a/main_test.go
+++ b/main_test.go
@@ -21,7 +21,8 @@ func TestLoad(t *testing.T) {
 			require.Contains(t, buf.String(), "CREATE TABLE")
 			require.Contains(t, buf.String(), "pets")
 			require.Contains(t, buf.String(), "users")
-			require.NotContains(t, buf.String(), "toys") // Struct without GORM annotations.
+			require.Contains(t, buf.String(), "toys")
+			require.NotContains(t, buf.String(), "houses") // Struct without GORM annotations.
 		})
 	}
 }


### PR DESCRIPTION
Addresses this issue: [https://github.com/ariga/atlas-provider-gorm/issues/22](https://github.com/ariga/atlas-provider-gorm/issues/22)