### PR TITLE
Fix wrong params in test

### DIFF
--- a/gormschema/gorm_test.go
+++ b/gormschema/gorm_test.go
@@ -89,8 +89,8 @@ func resetSession() {
 	}
 }
 
-func requireEqualContent(t *testing.T, expected, fileName string) {
+func requireEqualContent(t *testing.T, actual, fileName string) {
 	buf, err := os.ReadFile(fileName)
 	require.NoError(t, err)
-	require.Equal(t, expected, string(buf))
+	require.Equal(t, string(buf), actual)
 }


### PR DESCRIPTION
Function definition is:

https://github.com/stretchr/testify/blob/bb548d0473d4e1c9b7bbfd6602c7bf12f7a84dd2/require/require.go#L155

```go
func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface)
```

**content from file** should be `expected` result, not `actual` result