### PR TITLE
internal/testdata: skip rename_constraint for SQL Server

### DIFF
--- a/internal/testdata/atlas.hcl
+++ b/internal/testdata/atlas.hcl
@@ -29,6 +29,11 @@ env "gorm" {
   migration {
     dir = "file://migrations/${var.dialect}"
   }
+  diff {
+    skip {
+      rename_constraint = true
+    }
+  }
   format {
     migrate {
       diff = "{{ sql . \"  \" }}"

--- a/internal/testdata/circularfks/atlas.hcl
+++ b/internal/testdata/circularfks/atlas.hcl
@@ -29,6 +29,11 @@ env "gorm" {
   migration {
     dir = "file://migrations/${var.dialect}"
   }
+  diff {
+    skip {
+      rename_constraint = true
+    }
+  }
   format {
     migrate {
       diff = "{{ sql . \"  \" }}"


### PR DESCRIPTION
Because GORM doesn't allow the user naming the PK, so SQL Server generated the random one, Atlas will generate the rename constraint every time the user run `migrate diff`. This skip policy ignore annoying changes in the test