### PR TITLE
gormschema: create separate config copies for each gorm.Open call

### DIFF
--- a/gormschema/gorm.go
+++ b/gormschema/gorm.go
@@ -186,7 +186,8 @@ func (l *Loader) Load(models ...any) (string, error) {
 	default:
 		return "", fmt.Errorf("unsupported engine: %s", l.dialect)
 	}
-	db, err := gorm.Open(di, l.config)
+	cfg := *l.config
+	db, err := gorm.Open(di, &cfg)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
https://github.com/go-gorm/gorm/pull/7518/files 

New GORM changed config handling to use the passed config object directly instead of copying it. This caused the shared l.config to be modified by the second gorm.Open() call, contaminating the first database's dialector and causing the custom migrator to be used unintentionally for AutoMigrate operations.