### PR TITLE
fix: quote generated model positions in loader template

### DIFF
--- a/loader.tmpl
+++ b/loader.tmpl
@@ -18,7 +18,7 @@ func main() {
 		{{- end -}}
 			, gormschema.WithModelPosition(map[any]string{
 				{{- range .Models }}
-					&{{ . }}{}: "{{ .Pos }}",
+					&{{ . }}{}: {{ printf "%q" .Pos }},
 				{{- end }}
 				})).Load(
 		{{- range .Models }}


### PR DESCRIPTION
The standalone loader template currently injects model source positions into generated Go code using raw double-quoted strings.

On Windows, these positions contain backslashes, for example:

    C:\Users\name\project\models\user.go:12

Embedding that value directly produces invalid Go string literals such as "\U", "\p", or "\m", which causes the generated loader to fail with "unknown escape sequence".

Use printf "%q" when rendering the position so the value is emitted as a valid Go string literal on all platforms.

Fixes #69.